### PR TITLE
Restructure Relay multi-project example

### DIFF
--- a/test/integration/relay-graphql-swc-multi-project/project-a/__generated__/pagesAQuery.graphql.ts
+++ b/test/integration/relay-graphql-swc-multi-project/project-a/__generated__/pagesAQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<187ead9fb6e7b26d71c9161bda6ab902>>
+ * @generated SignedSource<<afaeba3a661c4bb0d2a399327c82d32b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,15 +9,15 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime'
-export type pagesQuery$variables = {}
-export type pagesQueryVariables = pagesQuery$variables
-export type pagesQuery$data = {
+export type pagesAQuery$variables = {}
+export type pagesAQueryVariables = pagesAQuery$variables
+export type pagesAQuery$data = {
   readonly greeting: string
 }
-export type pagesQueryResponse = pagesQuery$data
-export type pagesQuery = {
-  variables: pagesQueryVariables
-  response: pagesQuery$data
+export type pagesAQueryResponse = pagesAQuery$data
+export type pagesAQuery = {
+  variables: pagesAQueryVariables
+  response: pagesAQuery$data
 }
 
 const node: ConcreteRequest = (function () {
@@ -35,7 +35,7 @@ const node: ConcreteRequest = (function () {
       argumentDefinitions: [],
       kind: 'Fragment',
       metadata: null,
-      name: 'pagesQuery',
+      name: 'pagesAQuery',
       selections: v0 /*: any*/,
       type: 'Query',
       abstractKey: null,
@@ -44,20 +44,20 @@ const node: ConcreteRequest = (function () {
     operation: {
       argumentDefinitions: [],
       kind: 'Operation',
-      name: 'pagesQuery',
+      name: 'pagesAQuery',
       selections: v0 /*: any*/,
     },
     params: {
-      cacheID: '167b6de16340efeb876a7787c90e7cec',
+      cacheID: 'bc59dc1b50eecd19488f004d5cd93913',
       id: null,
       metadata: {},
-      name: 'pagesQuery',
+      name: 'pagesAQuery',
       operationKind: 'query',
-      text: 'query pagesQuery {\n  greeting\n}\n',
+      text: 'query pagesAQuery {\n  greeting\n}\n',
     },
   }
 })()
 
-;(node as any).hash = '4017856344f36f61252354e2eb442d98'
+;(node as any).hash = '7f699085b71746bb18cb74e3a0776f46'
 
 export default node

--- a/test/integration/relay-graphql-swc-multi-project/project-a/next.config.js
+++ b/test/integration/relay-graphql-swc-multi-project/project-a/next.config.js
@@ -4,7 +4,7 @@ module.exports = {
   experimental: {
     relay: {
       src: './pages',
-      artifactDirectory: '../__generated__',
+      artifactDirectory: './__generated__',
       language: relay.projects['project-b'].language,
     },
     externalDir: true,

--- a/test/integration/relay-graphql-swc-multi-project/project-a/pages/index.tsx
+++ b/test/integration/relay-graphql-swc-multi-project/project-a/pages/index.tsx
@@ -8,7 +8,7 @@ import {
   Store,
 } from 'relay-runtime'
 import { GetServerSideProps } from 'next'
-import { pagesQuery } from '../../__generated__/pagesQuery.graphql'
+import { pagesAQuery } from '../__generated__/pagesAQuery.graphql'
 
 type Props = { greeting: string }
 
@@ -41,10 +41,10 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
     network: Network.create(createGraphQLFetcher(req.headers.host)),
   })
 
-  const result = await fetchQuery<pagesQuery>(
+  const result = await fetchQuery<pagesAQuery>(
     environment,
     graphql`
-      query pagesQuery {
+      query pagesAQuery {
         greeting
       }
     `,

--- a/test/integration/relay-graphql-swc-multi-project/project-b/__generated__/pagesBQuery.graphql.ts
+++ b/test/integration/relay-graphql-swc-multi-project/project-b/__generated__/pagesBQuery.graphql.ts
@@ -1,0 +1,63 @@
+/**
+ * @generated SignedSource<<9f92ea3ccfda1f64fa269e68b912abae>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime'
+export type pagesBQuery$variables = {}
+export type pagesBQueryVariables = pagesBQuery$variables
+export type pagesBQuery$data = {
+  readonly greeting: string
+}
+export type pagesBQueryResponse = pagesBQuery$data
+export type pagesBQuery = {
+  variables: pagesBQueryVariables
+  response: pagesBQuery$data
+}
+
+const node: ConcreteRequest = (function () {
+  var v0 = [
+    {
+      alias: null,
+      args: null,
+      kind: 'ScalarField',
+      name: 'greeting',
+      storageKey: null,
+    },
+  ]
+  return {
+    fragment: {
+      argumentDefinitions: [],
+      kind: 'Fragment',
+      metadata: null,
+      name: 'pagesBQuery',
+      selections: v0 /*: any*/,
+      type: 'Query',
+      abstractKey: null,
+    },
+    kind: 'Request',
+    operation: {
+      argumentDefinitions: [],
+      kind: 'Operation',
+      name: 'pagesBQuery',
+      selections: v0 /*: any*/,
+    },
+    params: {
+      cacheID: 'e7cc6f8c55ef42783faec7a49b72ae71',
+      id: null,
+      metadata: {},
+      name: 'pagesBQuery',
+      operationKind: 'query',
+      text: 'query pagesBQuery {\n  greeting\n}\n',
+    },
+  }
+})()
+
+;(node as any).hash = '83bf9452eafa7635d81bdc98603cd75f'
+
+export default node

--- a/test/integration/relay-graphql-swc-multi-project/project-b/next.config.js
+++ b/test/integration/relay-graphql-swc-multi-project/project-b/next.config.js
@@ -4,7 +4,7 @@ module.exports = {
   experimental: {
     relay: {
       src: './pages',
-      artifactDirectory: '../__generated__',
+      artifactDirectory: './__generated__',
       language: relay.projects['project-b'].language,
     },
     externalDir: true,

--- a/test/integration/relay-graphql-swc-multi-project/project-b/pages/index.tsx
+++ b/test/integration/relay-graphql-swc-multi-project/project-b/pages/index.tsx
@@ -8,7 +8,7 @@ import {
   Store,
 } from 'relay-runtime'
 import { GetServerSideProps } from 'next'
-import { pagesQuery } from '../../__generated__/pagesQuery.graphql'
+import { pagesBQuery } from '../__generated__/pagesBQuery.graphql'
 
 type Props = { greeting: string }
 
@@ -41,10 +41,10 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
     network: Network.create(createGraphQLFetcher(req.headers.host)),
   })
 
-  const result = await fetchQuery<pagesQuery>(
+  const result = await fetchQuery<pagesBQuery>(
     environment,
     graphql`
-      query pagesQuery {
+      query pagesBQuery {
         greeting
       }
     `,

--- a/test/integration/relay-graphql-swc-multi-project/relay.config.js
+++ b/test/integration/relay-graphql-swc-multi-project/relay.config.js
@@ -8,12 +8,12 @@ module.exports = {
     'project-a': {
       schema: 'schema.graphql',
       language: 'typescript',
-      output: '__generated__',
+      output: 'project-a/__generated__',
     },
     'project-b': {
       schema: 'schema.graphql',
       language: 'typescript',
-      output: '__generated__',
+      output: 'project-b/__generated__',
     },
   },
 }


### PR DESCRIPTION
With this change `project-a` and `project-b` will have different output directories (which is a typical setup for multi-project config) to prevent collision between generated artifacts.
